### PR TITLE
Configure swagger with HTTP-only and allow all requests to /api/docs

### DIFF
--- a/src/main/java/dev/realtards/kuenyawz/configurations/OpenAPIConfig.java
+++ b/src/main/java/dev/realtards/kuenyawz/configurations/OpenAPIConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,11 +17,18 @@ public class OpenAPIConfig {
 	public OpenAPI customOpenAPI() {
 		return new OpenAPI()
 			.components(new Components()
-				.addSecuritySchemes("bearerAuth",
+				.addSecuritySchemes("cookieAuth",
 					new SecurityScheme()
-						.type(SecurityScheme.Type.HTTP)
-						.scheme("bearer")
-						.bearerFormat("JWT")))
+						.type(SecurityScheme.Type.APIKEY)
+						.in(SecurityScheme.In.COOKIE)
+						.name("accessToken")
+						.description("HTTP-only cookie authentication"))
+				.addSecuritySchemes("refreshCookie",
+					new SecurityScheme()
+						.type(SecurityScheme.Type.APIKEY)
+						.in(SecurityScheme.In.COOKIE)
+						.name("refreshToken")
+						.description("HTTP-only refresh token cookie")))
 			.info(new Info()
 				.title("KuenyaWZ API")
 				.version("1.0.0")
@@ -32,6 +40,8 @@ public class OpenAPIConfig {
 				.license(new License()
 					.name("MIT")
 					.url("https://github.com/vianneynara/kuenyawz-api/blob/main/LICENSE"))
-			);
+			)
+			.addSecurityItem(new SecurityRequirement().addList("cookieAuth"))
+			.addSecurityItem(new SecurityRequirement().addList("refreshCookie"));
 	}
 }

--- a/src/main/java/dev/realtards/kuenyawz/configurations/security/SecurityConfig.java
+++ b/src/main/java/dev/realtards/kuenyawz/configurations/security/SecurityConfig.java
@@ -107,7 +107,7 @@ public class SecurityConfig {
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		return (web) -> web.ignoring()
 			.requestMatchers(
-				"/api/docs/v3**",
+				"/api/docs/**",
 				"/swagger-ui/**",
 				"/swagger-ui.html",
 				"/favicon.ico"

--- a/src/main/java/dev/realtards/kuenyawz/controllers/AccountController.java
+++ b/src/main/java/dev/realtards/kuenyawz/controllers/AccountController.java
@@ -34,7 +34,7 @@ public class AccountController extends BaseController {
 
 	@Operation(summary = "(Master) Get all accounts",
 		description = "Retrieves a list of all accounts with secure information",
-		security = @SecurityRequirement(name = "bearerAuth")
+		security = @SecurityRequirement(name = "cookieAuth")
 	)
 	@ApiResponse(responseCode = "200", description = "Successfully retrieved all accounts",
 		content = @Content(
@@ -42,7 +42,7 @@ public class AccountController extends BaseController {
 			schema = @Schema(implementation = ListOfAccountDto.class)
 		)
 	)
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN"})
 	@GetMapping
 	public ResponseEntity<Object> getAllAccounts() {
 		List<AccountSecureDto> accounts = accountService.getAllAccounts();
@@ -70,7 +70,7 @@ public class AccountController extends BaseController {
 			)
 		)
 	)
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN"})
 	@PostMapping
 	public ResponseEntity<Object> createAccount(
 		@Valid @RequestBody AccountRegistrationDto accountRegistrationDto
@@ -86,7 +86,7 @@ public class AccountController extends BaseController {
 			schema = @Schema(implementation = AccountSecureDto.class)
 		)
 	)
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN", "USER"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN", "USER"})
 	@GetMapping("{accountId}")
 	public ResponseEntity<Object> getAccount(
 		@PathVariable Long accountId
@@ -102,7 +102,7 @@ public class AccountController extends BaseController {
 			schema = @Schema(implementation = AccountSecureDto.class)
 		)
 	)
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN", "USER"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN", "USER"})
 	@PutMapping("{accountId}")
 	public ResponseEntity<Object> updateAccount(
 		@PathVariable Long accountId,
@@ -114,7 +114,7 @@ public class AccountController extends BaseController {
 
 	@Operation(summary = "Delete an account", description = "Deletes an account with the provided account ID")
 	@ApiResponse(responseCode = "204", description = "Successfully deleted account")
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN"})
 	@DeleteMapping("{accountId}")
 	public ResponseEntity<Object> deleteAccount(
 		@PathVariable Long accountId
@@ -132,7 +132,7 @@ public class AccountController extends BaseController {
 			schema = @Schema(implementation = AccountSecureDto.class)
 		)
 	)
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN", "USER"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN", "USER"})
 	@PatchMapping("{accountId}/account")
 	public ResponseEntity<Object> patchAccount(
 		@PathVariable Long accountId,
@@ -144,7 +144,7 @@ public class AccountController extends BaseController {
 
 	@Operation(summary = "Patch an account's password", description = "Patches with the provided request body")
 	@ApiResponse(responseCode = "204", description = "Successfully patched account's password")
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN", "USER"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN", "USER"})
 	@PatchMapping("{accountId}/password")
 	public ResponseEntity<Object> updatePassword(
 		@PathVariable Long accountId,
@@ -156,7 +156,7 @@ public class AccountController extends BaseController {
 
 	@Operation(summary = "Patch an account's privilege", description = "Patches with the provided request body")
 	@ApiResponse(responseCode = "204", description = "Successfully patched account's privilege")
-	@SecurityRequirement(name = "bearerAuth", scopes = {"ADMIN"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"ADMIN"})
 	@PatchMapping("{accountId}/privilege")
 	public ResponseEntity<Object> updatePrivilege(
 		@PathVariable Long accountId,

--- a/src/main/java/dev/realtards/kuenyawz/controllers/AuthController.java
+++ b/src/main/java/dev/realtards/kuenyawz/controllers/AuthController.java
@@ -159,8 +159,9 @@ public class AuthController {
 		refreshTokenCookie.setPath("/");
 		refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7);
 
-		authResponseDto.setAccessToken(null);
-		authResponseDto.setRefreshToken(null);
+		// TODO: Remove this after development
+//		authResponseDto.setAccessToken(null);
+//		authResponseDto.setRefreshToken(null);
 
 		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
 		assert requestAttributes != null : "Request attributes must not be null";

--- a/src/main/java/dev/realtards/kuenyawz/controllers/AuthController.java
+++ b/src/main/java/dev/realtards/kuenyawz/controllers/AuthController.java
@@ -96,6 +96,7 @@ public class AuthController {
 				schema = @Schema(implementation = AuthResponseDto.class)
 			))
 	})
+	@SecurityRequirement(name = "refreshCookie")
 	@PostMapping("/refresh")
 	public ResponseEntity<Object> refresh(
 		@Valid @RequestBody(required = false) AuthRefreshTokenDto tokenDto
@@ -115,7 +116,7 @@ public class AuthController {
 			)),
 		@ApiResponse(responseCode = "404", description = "User not found")
 	})
-	@SecurityRequirement(name = "bearerAuth", scopes = {"USER", "ADMIN"})
+	@SecurityRequirement(name = "cookieAuth", scopes = {"USER", "ADMIN"})
 	@GetMapping("/me")
 	public ResponseEntity<Object> me() {
 		AccountSecureDto accountSecureDto = authService.getCurrentUserInfo();

--- a/src/main/java/dev/realtards/kuenyawz/controllers/ProductController.java
+++ b/src/main/java/dev/realtards/kuenyawz/controllers/ProductController.java
@@ -65,7 +65,7 @@ public class ProductController extends BaseController {
 		),
 		@ApiResponse(responseCode = "400", description = "Invalid request body")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PostMapping
 	public ResponseEntity<Object> createProduct(
 		@Valid @RequestBody ProductPostDto productPostDto
@@ -127,7 +127,7 @@ public class ProductController extends BaseController {
 		@ApiResponse(responseCode = "204", description = "Product deleted successfully"),
 		@ApiResponse(responseCode = "404", description = "Product not found")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("{productId}")
 	public ResponseEntity<Object> softDeleteAllProducts(
 		@PathVariable Long productId
@@ -140,7 +140,7 @@ public class ProductController extends BaseController {
 	@ApiResponses({
 		@ApiResponse(responseCode = "204", description = "All products deleted successfully")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("/all")
 	public ResponseEntity<Object> softDeleteAllProducts() {
 		productService.softDeleteAllProducts();
@@ -157,7 +157,7 @@ public class ProductController extends BaseController {
 		@ApiResponse(responseCode = "404", description = "Product not found"),
 		@ApiResponse(responseCode = "400", description = "Invalid request body")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PatchMapping("{productId}")
 	public ResponseEntity<Object> patchProduct(
 		@PathVariable Long productId,
@@ -177,7 +177,7 @@ public class ProductController extends BaseController {
 		@ApiResponse(responseCode = "404", description = "Product not found"),
 		@ApiResponse(responseCode = "400", description = "Invalid request body")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PatchMapping("{productId}/availability")
 	public ResponseEntity<Object> patchProductAvailability(
 		@PathVariable Long productId,
@@ -233,7 +233,7 @@ public class ProductController extends BaseController {
 		@ApiResponse(responseCode = "404", description = "Product not found"),
 		@ApiResponse(responseCode = "400", description = "Invalid request body")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PostMapping("{productId}/variants/batch")
 	public ResponseEntity<Object> createVariants(
 		@PathVariable Long productId,
@@ -272,7 +272,7 @@ public class ProductController extends BaseController {
 		),
 		@ApiResponse(responseCode = "404", description = "Variant not found")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PatchMapping("{productId}/variants/{variantId}")
 	public ResponseEntity<Object> patchVariant(
 		@PathVariable Long productId,
@@ -288,7 +288,7 @@ public class ProductController extends BaseController {
 		@ApiResponse(responseCode = "204", description = "Variant deleted successfully"),
 		@ApiResponse(responseCode = "404", description = "Variant not found")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("{productId}/variants/{variantId}")
 	public ResponseEntity<Object> deleteVariant(
 		@PathVariable Long productId,
@@ -303,7 +303,7 @@ public class ProductController extends BaseController {
 		@ApiResponse(responseCode = "200", description = "Products imported successfully"),
 		@ApiResponse(responseCode = "400", description = "Invalid request body")
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PostMapping("/import")
 	public ResponseEntity<Object> importProductsFromCsv(
 		@Valid @ModelAttribute ProductCsvPostDto productCsvPostDto
@@ -314,7 +314,7 @@ public class ProductController extends BaseController {
 
 	// Non Exposed Endpoints
 
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("{productId}/permanent")
 	public ResponseEntity<Object> hardDeleteProduct(
 		@PathVariable Long productId
@@ -323,7 +323,7 @@ public class ProductController extends BaseController {
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("all/permanent")
 	public ResponseEntity<Object> hardDeleteAllProducts() {
 		productService.hardDeleteAllProducts();

--- a/src/main/java/dev/realtards/kuenyawz/controllers/ProductImageController.java
+++ b/src/main/java/dev/realtards/kuenyawz/controllers/ProductImageController.java
@@ -44,7 +44,7 @@ public class ProductImageController extends BaseController {
 		@ApiResponse(responseCode = "400", description = "Invalid image file"),
 		@ApiResponse(responseCode = "404", description = "Product not found"),
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PostMapping("{productId}")
 	public ResponseEntity<Object> uploadImage(
 		@PathVariable Long productId,
@@ -61,7 +61,7 @@ public class ProductImageController extends BaseController {
 		@ApiResponse(responseCode = "400", description = "Invalid image file"),
 		@ApiResponse(responseCode = "404", description = "Product not found"),
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@PostMapping("{productId}/batch")
 	public ResponseEntity<Object> batchUploadImage(
 		@PathVariable Long productId,
@@ -100,7 +100,7 @@ public class ProductImageController extends BaseController {
 		@ApiResponse(responseCode = "204", description = "Image deleted successfully"),
 		@ApiResponse(responseCode = "404", description = "Product or image not found"),
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("{productId}/{resourceUri}")
 	public ResponseEntity<Object> deleteImage(
 		@PathVariable Long productId,
@@ -115,7 +115,7 @@ public class ProductImageController extends BaseController {
 		@ApiResponse(responseCode = "204", description = "Images deleted successfully"),
 		@ApiResponse(responseCode = "404", description = "Product not found"),
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("{productId}")
 	public ResponseEntity<Object> deleteAllImagesOfProduct(
 		@PathVariable Long productId
@@ -128,7 +128,7 @@ public class ProductImageController extends BaseController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "Images deleted successfully"),
 	})
-	@SecurityRequirement(name = "bearerAuth")
+	@SecurityRequirement(name = "cookieAuth")
 	@DeleteMapping("all")
 	public ResponseEntity<Object> deleteAllImages() {
 		imageStorageService.deleteAll();


### PR DESCRIPTION
Current security schemas:
```java
	.components(new Components()
		.addSecuritySchemes("cookieAuth",
			new SecurityScheme()
				.type(SecurityScheme.Type.APIKEY)
				.in(SecurityScheme.In.COOKIE)
				.name("accessToken")
				.description("HTTP-only cookie authentication"))
		.addSecuritySchemes("refreshCookie",
			new SecurityScheme()
				.type(SecurityScheme.Type.APIKEY)
				.in(SecurityScheme.In.COOKIE)
				.name("refreshToken")
				.description("HTTP-only refresh token cookie")))
```

Enabled returning tokens in login/register response.