### PR TITLE
Add resource caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/dev/kons/kuenyawz/KuenyaWZApiApplication.java
+++ b/src/main/java/dev/kons/kuenyawz/KuenyaWZApiApplication.java
@@ -3,11 +3,13 @@ package dev.kons.kuenyawz;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableConfigurationProperties
+@EnableCaching
 public class KuenyaWZApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,9 @@ management.endpoint.health.show-details=when_authorized
 logging.level.dev.kons.kuenyawz.filters.RequestLoggingFilter=DEBUG
 #logging.level.org.springframework.security=trace
 
+# Caching Configuration
+spring.cache.cache-names=productsCache,productDto,purchasesCache
+
 # Documentation Configuration
 springdoc.swagger-ui.path=/swagger-ui
 springdoc.swagger-ui.operations-sorter=alpha


### PR DESCRIPTION
`@Cacheables` are implemented in these frequent endpoints:
- GET `/api/orders` -> PurchaseServiceImpl::findAll
- GET `/api/products` -> PurchaseServiceImpl::getAllProductsPaginated
- GET `/api/products/{productId}` -> PurchaseServiceImpl::getProducts

These cacheables are only invoked if `page` and `pageSize` is properly filled in the request parameter. They are used as the key towards the cache hash.