### PR TITLE
Hotfix: fix swagger configuration to work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
             <version>2.7.0</version>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${org.mapstruct.version}</version>

--- a/src/main/java/dev/kons/kuenyawz/configurations/security/SecurityConfig.java
+++ b/src/main/java/dev/kons/kuenyawz/configurations/security/SecurityConfig.java
@@ -67,7 +67,6 @@ public class SecurityConfig {
 					// Docs/Swagger access
 					.requestMatchers(
 						"/api/docs/**",
-						"/swagger/**",
 						"/swagger-ui/**",
 						"/favicon.ico").permitAll()
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,11 +41,9 @@ spring:
 
 springdoc:
     swagger-ui:
-        path: /swagger-ui
         operations-sorter: alpha
         # Not sure whether this will do anything
         enabled: true
-        config-url: /docs/v3
     api-docs:
         path: /docs/v3
 


### PR DESCRIPTION
Added `springdoc-openapi-starter-webmvc-api` version `2.7.0` dependency for the ui to work.